### PR TITLE
Add StructuredStreaming test

### DIFF
--- a/src/main/scala/RunStreamingDemo.scala
+++ b/src/main/scala/RunStreamingDemo.scala
@@ -1,0 +1,39 @@
+package myexample
+
+import com.example.protos.demo._
+import org.apache.spark.sql.streaming.{OutputMode, Trigger}
+import org.apache.spark.sql.{Dataset, SparkSession}
+import scalapb.spark.Implicits._
+
+object RunStreamingDemo {
+
+  def main(Args: Array[String]): Unit = {
+    val spark = SparkSession.builder().appName("ScalaPB Streaming Demo").getOrCreate()
+
+    val rateStream = spark.readStream
+      .format("rate")
+      .option("rowsPerSecond", 10)
+      .load()
+      .map(row => Person().update(
+        _.name := row.getTimestamp(0).toString,
+        _.age := row.getLong(1).toInt,
+        _.gender := Gender.FEMALE)
+      )
+
+    val streamingQuery = rateStream.writeStream
+      .outputMode(OutputMode.Append())
+      .trigger(Trigger.ProcessingTime(1000))
+      .foreachBatch(processMicroBatch _)
+      .format("console")
+      .start()
+
+    streamingQuery.awaitTermination()
+
+  }
+
+  def processMicroBatch(batch: Dataset[Person], batchID: Long): Unit = {
+    val result = batch.select("age", "name").collect()
+    println(result)
+  }
+
+}


### PR DESCRIPTION
With this snippet, I was able to reproduce the issue I'm having in my production code when deploying to [Databricks runtime 10.5](https://docs.databricks.com/release-notes/runtime/10.5.html#system-environment) (Spark 3.2.1, Scala 2.12). The error is:

```
Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: Task not serializable: java.io.NotSerializableException: scalapb.descriptors.FieldDescriptor
Serialization stack:
	- object not serializable (class: scalapb.descriptors.FieldDescriptor, value: Person.name)
```
The following stacktrace also appears in the logs, and it might provide additional context:

```
ERROR SQLUsageLogging:94 - Exception while logging query profile
com.databricks.sql.serialization.marshalling.MarshallingException: Cannot convert scalapb.descriptors.FieldDescriptor Literal to proto message: Person.name
	at com.databricks.sql.serialization.marshalling.LiteralMarshaller$.buildProto(leafExpressionMarshallers.scala:179)
	at com.databricks.sql.serialization.marshalling.LiteralMarshaller$.buildProto(leafExpressionMarshallers.scala:94)
	at com.databricks.sql.serialization.marshalling.LiteralMarshaller$.buildProto(leafExpressionMarshallers.scala:82)
	at com.databricks.sql.serialization.marshalling.SingleTagExpressionMarshaller.toProto(ExpressionMarshaller.scala:62)
	at com.databricks.sql.serialization.marshalling.SingleTagExpressionMarshaller.toProto$(ExpressionMarshaller.scala:59)
....

```

Note that `mypackage.RunDemo` batch test runs successfully on the same environment.

(I was unsure if a PR is the best way to demonstrate the problem, but I thought it would be useful to have a test specific for the streaming APIs in this codebase. Feel free to decline if it's not appropriate)
